### PR TITLE
Update types.F90

### DIFF
--- a/src/types.F90
+++ b/src/types.F90
@@ -1103,8 +1103,8 @@ module types
  	    real (kind=c_float) :: rNorthernLatitude = rNO_DATA_NCDC
 
       ! define GDD associated with the start of the growing season
-      real (kind=c_float)  :: fGrowingSeasonStart_Minimum_GDD = 90.0_c_float
-      real (kind=c_float)  :: fGrowingSeasonEnd_KillingFrostTemp = 28.5_c_float
+      real (kind=c_float)  :: rGrowingSeasonStart_Minimum_GDD = 90.0_c_float
+      real (kind=c_float)  :: rGrowingSeasonEnd_KillingFrostTemp = 28.5_c_float
 
 #ifdef STREAM_INTERACTIONS
  	    ! Data for the elevation corrections on temperature


### PR DESCRIPTION
Should fGrowingSeasonStart_Minimum_GDD & fGrowingSeasonEnd_KillingFrostTemp be changed to  rGrowingSeasonStart_Minimum_GDD & rGrowingSeasonEnd_KillingFrostTemp? I don't know fortran...yet... but it seems other floats are preceded by an 'r'